### PR TITLE
Add convert-hf-to-gguf

### DIFF
--- a/LlamaCpp/Quantizing_with_LlamaCpp.md
+++ b/LlamaCpp/Quantizing_with_LlamaCpp.md
@@ -188,7 +188,7 @@ python convert.py models\model_dir\ --outtype f16 --vocab-type bpe
 [Optional] Some models require the convert-hf-to-gguf.py script instead of the convert.py script. I am not sure about the actual requirements, but I believe it is for safetensor files.
 
 ```
-python convert-hf-to-gguf.py models\mymodel\ outtype f16
+python convert-hf-to-gguf.py models\mymodel\ --outtype f16
 ```
 
 ## Do the quantization in the llama.cpp\build\bin directory.

--- a/LlamaCpp/Quantizing_with_LlamaCpp.md
+++ b/LlamaCpp/Quantizing_with_LlamaCpp.md
@@ -184,6 +184,13 @@ python convert.py models\model_dir\ --outtype f16
 ```
 python convert.py models\model_dir\ --outtype f16 --vocab-type bpe
 ```
+
+[Optional] Some models require the convert-hf-to-gguf.py script instead of the convert.py script. I am not sure about the actual requirements, but I believe it is for safetensor files.
+
+```
+python convert-hf-to-gguf.py models\mymodel\ outtype f16
+```
+
 ## Do the quantization in the llama.cpp\build\bin directory.
 Quantization is not done in python VENV. ('deactivate' the venv)  
 List the models in the model directory (copy the name for the model_dir)  


### PR DESCRIPTION
I am not yet sure about the requirements, but some models only can be converted to gguf with convert-hf-to-gguf instead of convert.py